### PR TITLE
Batching, table exclusion, gzipping

### DIFF
--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -321,7 +321,7 @@ class Anonymizer extends \Arrilot\DataAnonymization\Anonymizer
             unset($tableContent);
 
 
-        } while ($hasContent && $currentBatch < 1);
+        } while ($hasContent);
 
         if ($hasHeader) {
             $this->writeInsertEnd();

--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -190,6 +190,10 @@ class Anonymizer extends \Arrilot\DataAnonymization\Anonymizer
 
             $currentBatch++;
 
+            // Memory cleanup
+            unset($tableContent);
+
+
         } while ($hasContent);
 
         if ($hasHeader) {

--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -11,7 +11,7 @@ class Anonymizer extends \Arrilot\DataAnonymization\Anonymizer
     /**
      * @var int
      */
-    protected $batchSize = 1000;
+    protected $batchSize = 10000;
 
     /**
      * Perform export with anonymized tables
@@ -187,6 +187,9 @@ class Anonymizer extends \Arrilot\DataAnonymization\Anonymizer
                 $this->writeTableContent($tableContent, $table);
 
             }
+
+            $currentBatch++;
+
         } while ($hasContent);
 
         if ($hasHeader) {
@@ -229,7 +232,11 @@ class Anonymizer extends \Arrilot\DataAnonymization\Anonymizer
     {
         $sql = "SELECT * FROM {$table}";
         if ($count) {
-            $sql .= "LIMIT ${count} OFFSET ${offset}";
+            $sql .= " LIMIT ";
+            if ($offset) {
+                $sql .= "${offset}, ";
+            }
+            $sql .= "${count}";
         }
 
         return $this->database->query($sql);

--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -56,6 +56,11 @@ class Anonymizer extends \Arrilot\DataAnonymization\Anonymizer
     protected $tablesToExport = [];
 
     /**
+     * @var array
+     */
+    protected $tablesToExclude = [];
+
+    /**
      * @param string $exportPath
      *
      * @return void
@@ -76,6 +81,8 @@ class Anonymizer extends \Arrilot\DataAnonymization\Anonymizer
         } else {
             $tables = $this->tablesToExport;
         }
+
+        $tables = array_diff($tables, $this->tablesToExclude);
 
         return $tables;
     }
@@ -142,6 +149,18 @@ class Anonymizer extends \Arrilot\DataAnonymization\Anonymizer
     }
 
     /**
+     * @param string $table
+     *
+     * @return void
+     */
+    public function addTableToExclude($table)
+    {
+        if (!isset($this->tablesToExclude[$table])) {
+            $this->tablesToExclude[] = $table;
+        }
+    }
+
+    /**
      * @param array $tables
      *
      * @return void
@@ -156,6 +175,24 @@ class Anonymizer extends \Arrilot\DataAnonymization\Anonymizer
 
         foreach ($tables as $table) {
             $this->addTableToExport($table);
+        }
+    }
+
+    /**
+     * @param array $tables
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function addTablesToExclude(array $tables)
+    {
+        if (empty($tables)) {
+            throw new \Exception('addTablesToExclude argument needs to be a non-empty array');
+        }
+
+        foreach ($tables as $table) {
+            $this->addTableToExclude($table);
         }
     }
 


### PR DESCRIPTION
Needed to use your library for a project, but required some additional functionality:
- Now supports batching, setting batch size. Memory usage remains consistent.
- Supports dumping to gzipped sql (default).
- Supports excluding tables
- Supports dumping specified tables truncated (only structure, no data)
- Supports verbose logging to track progress during batch dumps (off by default)

AFAIK, should be merge-able without breaking changes. Only the compression being on by default will make a difference in existing projects that aren't updated (which can be altered by setting `protected $compress = false;`, if desired).